### PR TITLE
Fix unnecessary increasing precision level for Y-axis labels

### DIFF
--- a/elroi.js
+++ b/elroi.js
@@ -1321,10 +1321,10 @@
             // The graph can contain only small values and scale ratio can be less than one
             // (more than one pixel is used per a value unit). And in combination with zero precision this can leads
             // to situation when labels with fractional numbers are too over-aggressively rounded and it looks confusing.
-            // So in that case precision will be increased.
+            // If there is more than ten pixels are used per a value unit the precision should be increased.
             if (precision === 0
                 // scale ratio check
-                && graph.yTicks[axis.seriesIndex] > 1
+                && graph.yTicks[axis.seriesIndex] > 10
                 // labels contain fractional numbers check
                 && ((maxVal - minVal).toFixed(0) % (graph.options.grid.numYLabels - 1)) !== 0) {
 

--- a/lib/grid.js
+++ b/lib/grid.js
@@ -169,10 +169,10 @@
             // The graph can contain only small values and scale ratio can be less than one
             // (more than one pixel is used per a value unit). And in combination with zero precision this can leads
             // to situation when labels with fractional numbers are too over-aggressively rounded and it looks confusing.
-            // So in that case precision will be increased.
+            // If there is more than ten pixels are used per a value unit the precision should be increased.
             if (precision === 0
                 // scale ratio check
-                && graph.yTicks[axis.seriesIndex] > 1
+                && graph.yTicks[axis.seriesIndex] > 10
                 // labels contain fractional numbers check
                 && ((maxVal - minVal).toFixed(0) % (graph.options.grid.numYLabels - 1)) !== 0) {
 


### PR DESCRIPTION
The previous fix for rounding for labels of Y-axis contains scale ratio check with too small value. To avoid  unnecessary increasing precision level this value should be increased.